### PR TITLE
Add check for grantResults length

### DIFF
--- a/smsverifycatcher/build.gradle
+++ b/smsverifycatcher/build.gradle
@@ -11,6 +11,9 @@ android {
         versionCode 1
         versionName "1.0"
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
     buildTypes {
         release {
             minifyEnabled false
@@ -32,5 +35,7 @@ publish {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:2.19.0'
+
     compile 'com.android.support:appcompat-v7:25.3.0'
 }

--- a/smsverifycatcher/src/test/java/com/stfalcon/smsverifycatcher/SmsVerifyCatcherTest.java
+++ b/smsverifycatcher/src/test/java/com/stfalcon/smsverifycatcher/SmsVerifyCatcherTest.java
@@ -1,0 +1,60 @@
+package com.stfalcon.smsverifycatcher;
+
+import android.app.Activity;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static com.stfalcon.smsverifycatcher.SmsVerifyCatcher.PERMISSION_REQUEST_CODE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SmsVerifyCatcherTest {
+
+    private SmsVerifyCatcher catcher;
+
+    @Mock
+    public Activity activity;
+
+    @Mock
+    public OnSmsCatchListener<String> listener;
+
+
+    @Before
+    public void setUp() {
+        catcher = new SmsVerifyCatcher(activity, listener);
+    }
+
+
+    @After
+    public void tearDown() {
+        reset(activity, listener);
+    }
+
+    @Test
+    public void shouldNotRegisterReceiverWhenRequestWasCancelled() {
+        catcher.onRequestPermissionsResult(PERMISSION_REQUEST_CODE, new String[]{}, new int[]{});
+
+        verify(activity, never()).registerReceiver(any(SmsReceiver.class), any(IntentFilter.class));
+    }
+
+    @Test
+    public void shouldRegisterReceiverWhenPermissionsGranted() {
+        catcher.onRequestPermissionsResult(
+                PERMISSION_REQUEST_CODE,
+                new String[]{},
+                new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED}
+        );
+
+        verify(activity).registerReceiver(any(SmsReceiver.class), any(IntentFilter.class));
+    }
+}


### PR DESCRIPTION
A fix for 
```
Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=0; index=0
       at com.stfalcon.smsverifycatcher.SmsVerifyCatcher.onRequestPermissionsResult(SourceFile:87)
```
crash according to [Android Docs](https://developer.android.com/training/permissions/requesting#handle-response)