### PR TITLE
Permission Denied listener Added

### DIFF
--- a/sample/src/main/java/com/stfalcon/smsverifycatcher_sample/MainActivity.java
+++ b/sample/src/main/java/com/stfalcon/smsverifycatcher_sample/MainActivity.java
@@ -14,7 +14,7 @@ import com.stfalcon.smsverifycatcher.SmsVerifyCatcher;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements PermissionDeniedListener {
     private SmsVerifyCatcher smsVerifyCatcher;
 
     @Override
@@ -83,6 +83,6 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        smsVerifyCatcher.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        smsVerifyCatcher.onRequestPermissionsResult(requestCode, permissions, grantResults, this);
     }
 }

--- a/smsverifycatcher/src/main/java/com/stfalcon/smsverifycatcher/PermissionDeniedListener.java
+++ b/smsverifycatcher/src/main/java/com/stfalcon/smsverifycatcher/PermissionDeniedListener.java
@@ -1,0 +1,5 @@
+package com.stfalcon.smsverifycatcher;
+
+public interface PermissionDeniedListener {
+    void onPermissionDenied();
+}

--- a/smsverifycatcher/src/main/java/com/stfalcon/smsverifycatcher/SmsVerifyCatcher.java
+++ b/smsverifycatcher/src/main/java/com/stfalcon/smsverifycatcher/SmsVerifyCatcher.java
@@ -110,14 +110,17 @@ public class SmsVerifyCatcher {
         this.filter = regexp;
     }
 
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults, PermissionDeniedListener permissionDeniedListener) {
         switch (requestCode) {
             case PERMISSION_REQUEST_CODE:
                 if (grantResults.length > 1 &&
                         grantResults[0] == PackageManager.PERMISSION_GRANTED &&
                         grantResults[1] == PackageManager.PERMISSION_GRANTED) {
                     registerReceiver();
-                }
+                } else {
+					Toast.makeText(activity, "Permission denied, you have to manually enter OTP now", Toast.LENGTH_LONG).show();
+					permissionDeniedListener.onPermissionDenied();
+				}
                 break;
             default:
                 break;


### PR DESCRIPTION
There was no callback or listener present for the case when user denied the requested permission. So, I added a listener named `PermissionDeniedListener`  , and this can be called from the implementing activity, and required message to user can be shown. I have not added any external library for that, and so it is easily integrable. I have also made changes in the sample code so that you can check on your end that it should be included in your repository of this amazing library or not.